### PR TITLE
Fix auth mounting and redirect

### DIFF
--- a/components/common/ProtectedRoute.tsx
+++ b/components/common/ProtectedRoute.tsx
@@ -8,11 +8,12 @@ interface ProtectedRouteProps {
   requireAdmin?: boolean;
 }
 
-export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ 
-  children, 
-  requireAdmin = true 
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  children,
+  requireAdmin = true
 }) => {
   const { user, loading, isAdmin, error } = useAuth();
+  console.log('ProtectedRoute state', { user, loading, isAdmin, error });
 
   // Show loading spinner while checking authentication
   if (loading) {

--- a/components/pages/LoginPage.tsx
+++ b/components/pages/LoginPage.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Eye, EyeOff, Loader2, AlertCircle, CheckCircle2, Music } from "lucide-react";
 import { Input } from "../ui/input";
 import { useAuth } from "../../utils/auth/AuthContext";
 
 export function LoginPage() {
   const { signIn } = useAuth();
+  const navigate = useNavigate();
   const [showPassword, setShowPassword] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -17,10 +19,11 @@ export function LoginPage() {
     setIsLoading(true);
     setError("");
     setSuccess("");
-    
+
     try {
       await signIn(email, password);
       setSuccess("Authentication successful! Redirecting...");
+      navigate("/", { replace: true });
     } catch (error: any) {
       setError(error.message || "Login failed. Please check your credentials and try again.");
       console.error("Login error:", error);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -36,8 +36,19 @@ function App() {
   );
 }
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+const container = document.getElementById('root') as HTMLElement;
+const existingRoot = (container as any)._reactRoot as ReactDOM.Root | undefined;
+const root = existingRoot ?? ReactDOM.createRoot(container);
+if (!existingRoot) {
+  (container as any)._reactRoot = root;
+}
+
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/utils/auth/AuthContext.tsx
+++ b/utils/auth/AuthContext.tsx
@@ -258,3 +258,5 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     </AuthContext.Provider>
   );
 };
+
+export default AuthProvider;


### PR DESCRIPTION
## Summary
- ensure root is mounted once during HMR
- expose `AuthProvider` as default for Vite
- log auth state in `ProtectedRoute`
- redirect to dashboard after login

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a20865b648324927ddc3937685ef5