### PR TITLE
Fix HMR errors around AuthProvider

### DIFF
--- a/utils/auth/AuthContext.tsx
+++ b/utils/auth/AuthContext.tsx
@@ -259,4 +259,3 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   );
 };
 
-export default AuthProvider;


### PR DESCRIPTION
## Summary
- remove default export from `AuthContext.tsx`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a221fdefc8324a79b12e5c0ed3e87