### PR TITLE
Improve Supabase auth flow

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -45,7 +45,7 @@ const otherItems = [
 ];
 
 export function Dashboard() {
-  const { user, loading, isAdmin, signOut } = useAuth();
+  const { session, loading, isAdmin, signOut } = useAuth();
   const [activePage, setActivePage] = useState("Dashboard");
 
   // Show loading spinner while checking auth
@@ -61,7 +61,7 @@ export function Dashboard() {
   }
 
   // Show login page if not authenticated or not admin
-  if (!user || !isAdmin) {
+  if (!session || !isAdmin) {
     return <LoginPage />;
   }
 
@@ -144,15 +144,15 @@ export function Dashboard() {
           <div className="flex items-center space-x-3">
             <div className="w-8 h-8 bg-sonix-purple rounded-full flex items-center justify-center">
               <span className="text-white text-sm font-semibold">
-                {user.email?.charAt(0).toUpperCase()}
+                {session.user?.email?.charAt(0).toUpperCase()}
               </span>
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-sonix-primary truncate">
-                {user.user_metadata?.name || 'Admin'}
+                {session.user?.user_metadata?.name || 'Admin'}
               </p>
               <p className="text-xs text-sonix-secondary truncate">
-                {user.email}
+                {session.user?.email}
               </p>
             </div>
           </div>

--- a/components/common/ProtectedRoute.tsx
+++ b/components/common/ProtectedRoute.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../utils/auth/AuthContext';
-import { Loader2, Shield } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -10,10 +10,10 @@ interface ProtectedRouteProps {
 
 export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   children,
-  requireAdmin = true
+  requireAdmin = true,
 }) => {
-  const { user, loading, isAdmin, error } = useAuth();
-  console.log('ProtectedRoute state', { user, loading, isAdmin, error });
+  const { session, loading, isAdmin } = useAuth();
+  const location = useLocation();
 
   // Show loading spinner while checking authentication
   if (loading) {
@@ -30,30 +30,9 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     );
   }
 
-  // Show error state if there's an authentication error
-  if (!loading && error && !user) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4">
-        <div className="text-center max-w-md">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-red-500/20 rounded-2xl mb-4">
-            <Shield className="w-8 h-8 text-red-400" />
-          </div>
-          <h2 className="text-xl font-semibold text-white mb-2">Authentication Error</h2>
-          <p className="text-slate-400 mb-6">{error}</p>
-          <button 
-            onClick={() => window.location.reload()} 
-            className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
-          >
-            Retry
-          </button>
-        </div>
-      </div>
-    );
-  }
-
   // Redirect to login if user is not authenticated
-  if (!loading && !user) {
-    return <Navigate to="/login" replace />;
+  if (!loading && !session) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
   }
 
   // Check admin privileges if required

--- a/components/pages/LoginPage.tsx
+++ b/components/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { Eye, EyeOff, Loader2, AlertCircle, CheckCircle2, Music } from "lucide-react";
 import { Input } from "../ui/input";
 import { useAuth } from "../../utils/auth/AuthContext";
@@ -7,6 +7,8 @@ import { useAuth } from "../../utils/auth/AuthContext";
 export function LoginPage() {
   const { signIn } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as any)?.from?.pathname || "/";
   const [showPassword, setShowPassword] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -23,7 +25,7 @@ export function LoginPage() {
     try {
       await signIn(email, password);
       setSuccess("Authentication successful! Redirecting...");
-      navigate("/", { replace: true });
+      navigate(from, { replace: true });
     } catch (error: any) {
       setError(error.message || "Login failed. Please check your credentials and try again.");
       console.error("Login error:", error);


### PR DESCRIPTION
## Summary
- overhaul AuthContext to track session and admin status
- simplify ProtectedRoute redirection
- persist `from` path on login
- adjust dashboard to new context API

## Testing
- `npx tsc --noEmit`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688a28cb28f883248570fef1beb4d02d