### PR TITLE
Fix auth loading state

### DIFF
--- a/components/common/ProtectedRoute.tsx
+++ b/components/common/ProtectedRoute.tsx
@@ -14,6 +14,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 }) => {
   const { session, loading, isAdmin } = useAuth();
   const location = useLocation();
+  console.log('ProtectedRoute state', { loading, session, isAdmin });
 
   // Show loading spinner while checking authentication
   if (loading) {

--- a/utils/auth/AuthContext.tsx
+++ b/utils/auth/AuthContext.tsx
@@ -39,6 +39,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let mounted = true;
+    const timeout = setTimeout(() => {
+      setLoading(false);
+    }, 6000);
 
     const init = async () => {
       const { data } = await supabase.auth.getSession();
@@ -65,6 +68,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     return () => {
       mounted = false;
+      clearTimeout(timeout);
       listener.subscription.unsubscribe();
     };
   }, [supabase]);


### PR DESCRIPTION
## Summary
- add fail-safe timeout in `AuthProvider`
- log auth data in `ProtectedRoute`

## Testing
- `npx -y vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a2b4fd6e88324bd6c2787339371eb