### PR TITLE
Implement role-based admin check

### DIFF
--- a/components/common/ProtectedRoute.tsx
+++ b/components/common/ProtectedRoute.tsx
@@ -14,7 +14,6 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 }) => {
   const { session, loading, isAdmin } = useAuth();
   const location = useLocation();
-  console.log('ProtectedRoute state', { loading, session, isAdmin });
 
   // Show loading spinner while checking authentication
   if (loading) {
@@ -31,16 +30,13 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     );
   }
 
-  // Redirect to login if user is not authenticated
-  if (!loading && !session) {
+  if (!session) {
     return <Navigate to="/login" replace state={{ from: location }} />;
   }
 
-  // Check admin privileges if required
-  if (!loading && requireAdmin && !isAdmin) {
-    return <Navigate to="/login" replace />;
+  if (requireAdmin && !isAdmin) {
+    return <Navigate to="/unauthorized" replace />;
   }
 
-  // Render protected content
   return <>{children}</>;
 };

--- a/components/pages/UnauthorizedPage.tsx
+++ b/components/pages/UnauthorizedPage.tsx
@@ -1,0 +1,15 @@
+import { Link } from "react-router-dom";
+
+export function UnauthorizedPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-900 text-white p-4">
+      <div className="text-center space-y-4">
+        <h1 className="text-3xl font-bold">Access Denied</h1>
+        <p>You do not have permission to view this page.</p>
+        <Link to="/" className="text-sonix-purple underline">
+          Go back home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import { AuthProvider } from '../utils/auth/AuthContext'
 import { ProtectedRoute } from '../components/common/ProtectedRoute'
 import { DashboardPage } from '../components/pages/DashboardPage'
 import { LoginPage } from '../components/pages/LoginPage'
+import { UnauthorizedPage } from '../components/pages/UnauthorizedPage'
 import '../styles/globals.css'
 
 function App() {
@@ -20,6 +21,7 @@ function App() {
         <AuthProvider>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/unauthorized" element={<UnauthorizedPage />} />
             <Route
               path="/"
               element={


### PR DESCRIPTION
## Summary
- fetch user role from Supabase in `AuthContext`
- redirect non-admins to `/unauthorized`
- create new `UnauthorizedPage`
- register route for the page

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688a2d63cb2083249cc978e93f4937cb