### PR TITLE
Improve admin navigation and layout

### DIFF
--- a/components/layout/AdminLayout.tsx
+++ b/components/layout/AdminLayout.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { Outlet, NavLink } from "react-router-dom";
+import { Separator } from "../ui/separator";
+import { useAuth } from "../../utils/auth/AuthContext";
+import {
+  BarChart3,
+  Upload,
+  Mic,
+  Music,
+  FolderOpen,
+  Users,
+  CheckCircle,
+  TrendingUp,
+  LogIn,
+} from "lucide-react";
+
+const mainNavItems = [
+  { icon: BarChart3, label: "Dashboard", path: "/" },
+  { icon: Upload, label: "Upload", path: "/upload" },
+  { icon: Mic, label: "Artists", path: "/artists" },
+  { icon: Music, label: "Playlists", path: "/playlists" },
+];
+
+const contentItems = [
+  { icon: FolderOpen, label: "Uploads", path: "/uploads" },
+  { icon: Users, label: "Users", path: "/users" },
+  { icon: CheckCircle, label: "Verify Artists", path: "/verify-artists" },
+];
+
+const analyticsItems = [
+  { icon: TrendingUp, label: "Analytics", path: "/analytics" },
+];
+
+export function AdminLayout() {
+  const { session, signOut } = useAuth();
+  const [collapsed, setCollapsed] = useState(false);
+
+  const renderNavItem = (
+    item: { icon: any; label: string; path?: string },
+  ) => {
+    const Icon = item.icon;
+    if (item.label === "Logout") {
+      return (
+        <button
+          key={item.label}
+          onClick={signOut}
+          className="sonix-nav-item text-sonix-error w-full text-left"
+        >
+          <Icon className="w-5 h-5 text-sonix-error" />
+          <span>{item.label}</span>
+        </button>
+      );
+    }
+    return (
+      <NavLink
+        key={item.label}
+        to={item.path!}
+        end={item.path === "/"}
+        className={({ isActive }) =>
+          `sonix-nav-item w-full text-left ${
+            isActive ? "sonix-nav-item-active" : ""
+          }`
+        }
+      >
+        <Icon className="w-5 h-5" />
+        <span>{item.label}</span>
+      </NavLink>
+    );
+  };
+
+  return (
+    <div className="flex h-screen bg-sonix-black" style={{ fontFamily: 'Inter, system-ui, sans-serif' }}>
+      <div
+        className={`${collapsed ? 'w-20' : 'w-72'} bg-sonix-black border-r border-sonix flex flex-col transition-all duration-300`}
+      >
+        <div className="p-6 border-b border-sonix flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <div className="w-10 h-10 bg-gradient-to-br from-purple-600 via-purple-500 to-violet-600 rounded-2xl flex items-center justify-center sonix-glow">
+              <span className="text-white font-bold text-lg">🎵</span>
+            </div>
+            {!collapsed && (
+              <div>
+                <h1 className="text-lg font-bold text-sonix-primary">Sonix</h1>
+                <p className="text-xs text-sonix-secondary font-medium">Admin Dashboard</p>
+              </div>
+            )}
+          </div>
+          <button
+            onClick={() => setCollapsed(!collapsed)}
+            className="sonix-nav-item p-2 w-auto"
+          >
+            {collapsed ? '›' : '‹'}
+          </button>
+        </div>
+
+        <div className="p-4 border-b border-sonix">
+          <div className="flex items-center space-x-3">
+            <div className="w-8 h-8 bg-sonix-purple rounded-full flex items-center justify-center">
+              <span className="text-white text-sm font-semibold">
+                {session?.user?.email?.charAt(0).toUpperCase()}
+              </span>
+            </div>
+            {!collapsed && (
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-sonix-primary truncate">
+                  {session?.user?.user_metadata?.name || 'Admin'}
+                </p>
+                <p className="text-xs text-sonix-secondary truncate">
+                  {session?.user?.email}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <nav className="flex-1 p-6 space-y-8 overflow-y-auto">
+          <div className="space-y-2">
+            {mainNavItems.map(renderNavItem)}
+          </div>
+          <Separator style={{ backgroundColor: '#3F3F46' }} />
+          <div className="space-y-4">
+            {!collapsed && (
+              <div className="px-4">
+                <h3 className="text-xs font-bold text-sonix-secondary uppercase tracking-widest">Content</h3>
+              </div>
+            )}
+            <div className="space-y-2">
+              {contentItems.map(renderNavItem)}
+            </div>
+          </div>
+          <Separator style={{ backgroundColor: '#3F3F46' }} />
+          <div className="space-y-4">
+            {!collapsed && (
+              <div className="px-4">
+                <h3 className="text-xs font-bold text-sonix-secondary uppercase tracking-widest">Insights</h3>
+              </div>
+            )}
+            <div className="space-y-2">
+              {analyticsItems.map(renderNavItem)}
+            </div>
+          </div>
+          <Separator style={{ backgroundColor: '#3F3F46' }} />
+          <div className="space-y-2">
+            {renderNavItem({ icon: LogIn, label: 'Logout' })}
+          </div>
+        </nav>
+      </div>
+
+      <div className="flex-1 flex flex-col overflow-auto">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/components/pages/DashboardPage.tsx
+++ b/components/pages/DashboardPage.tsx
@@ -1,6 +1,5 @@
 import { Badge } from "../ui/badge";
-import { Button } from "../ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
+
 import { Upload, Users, CheckCircle, TrendingUp, Music, PlayCircle, Clock, Star, UserCheck, Loader2 } from "lucide-react";
 import { useRecentTracks, usePlatformStats, useVerificationRequests } from "../../utils/supabase/hooks";
 
@@ -10,43 +9,42 @@ const quickAccessCards = [
     description: "Add singles and albums to the platform",
     icon: Upload,
     iconColor: "text-sonix-purple",
-    href: "Upload"
+    href: "/upload"
   },
   {
     title: "Manage Artists", 
     description: "Browse and edit artist profiles",
     icon: Users,
     iconColor: "text-sonix-green",
-    href: "Artists"
+    href: "/artists"
   },
   {
     title: "Platform Users",
     description: "Manage user accounts and roles",
     icon: UserCheck,
     iconColor: "text-sonix-purple",
-    href: "Users"
+    href: "/users"
   },
   {
     title: "Content Library",
     description: "View all uploaded content",
     icon: Music,
     iconColor: "text-orange-400",
-    href: "Uploads"
+    href: "/uploads"
   },
   {
     title: "Platform Analytics",
     description: "Performance insights and reports",
     icon: TrendingUp,
     iconColor: "text-pink-400",
-    href: "Analytics"
+    href: "/analytics"
   }
 ];
 
-interface DashboardPageProps {
-  onNavigate: (page: string) => void;
-}
+import { useNavigate } from "react-router-dom";
 
-export function DashboardPage({ onNavigate }: DashboardPageProps) {
+export function DashboardPage() {
+  const navigate = useNavigate();
   const { data: recentTracks, loading: tracksLoading } = useRecentTracks(4);
   const { stats: platformStats, loading: statsLoading } = usePlatformStats() as {
     stats: any;
@@ -93,7 +91,7 @@ export function DashboardPage({ onNavigate }: DashboardPageProps) {
               return (
                 <button
                   key={card.title}
-                  onClick={() => onNavigate(card.href)}
+                  onClick={() => navigate(card.href)}
                   className="sonix-card hover:sonix-shadow-lg transition-all duration-300 hover:-translate-y-1 text-left group hover:sonix-glow"
                 >
                   <div className="flex items-center justify-between mb-4">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,14 @@ import { SupabaseAuthProvider } from '../contexts/SupabaseAuthProvider'
 import { AuthProvider } from '../utils/auth/AuthContext'
 import { ProtectedRoute } from '../components/common/ProtectedRoute'
 import { DashboardPage } from '../components/pages/DashboardPage'
+import { UploadPage } from '../components/pages/UploadPage'
+import { ArtistsPage } from '../components/pages/ArtistsPage'
+import { PlaylistsPage } from '../components/pages/PlaylistsPage'
+import { UploadsPage } from '../components/pages/UploadsPage'
+import { UsersPage } from '../components/pages/UsersPage'
+import { VerifyArtistsPage } from '../components/pages/VerifyArtistsPage'
+import { AnalyticsPage } from '../components/pages/AnalyticsPage'
+import { AdminLayout } from '../components/layout/AdminLayout'
 import { LoginPage } from '../components/pages/LoginPage'
 import { UnauthorizedPage } from '../components/pages/UnauthorizedPage'
 import '../styles/globals.css'
@@ -26,10 +34,19 @@ function App() {
               path="/"
               element={
                 <ProtectedRoute requireAdmin={true}>
-                  <DashboardPage onNavigate={() => {}} />
+                  <AdminLayout />
                 </ProtectedRoute>
               }
-            />
+            >
+              <Route index element={<DashboardPage />} />
+              <Route path="upload" element={<UploadPage />} />
+              <Route path="artists" element={<ArtistsPage />} />
+              <Route path="playlists" element={<PlaylistsPage />} />
+              <Route path="uploads" element={<UploadsPage />} />
+              <Route path="users" element={<UsersPage />} />
+              <Route path="verify-artists" element={<VerifyArtistsPage />} />
+              <Route path="analytics" element={<AnalyticsPage />} />
+            </Route>
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </AuthProvider>


### PR DESCRIPTION
## Summary
- create `AdminLayout` with persistent sidebar
- integrate layout into router
- update dashboard navigation to use `useNavigate`

## Testing
- `npx vitest run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a4d1961548324a78e3ac958179f96