### PR TITLE
Refactor pages to use Supabase hooks

### DIFF
--- a/components/pages/ArtistsPage.tsx
+++ b/components/pages/ArtistsPage.tsx
@@ -3,82 +3,17 @@ import { Search, Plus, MoreHorizontal, Star, Users, Music, TrendingUp } from "lu
 import { Input } from "../ui/input";
 import { Avatar, AvatarFallback } from "../ui/avatar";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/dropdown-menu";
+import { useArtists } from "../../utils/supabase/hooks";
+import { Skeleton } from "../ui/skeleton";
 
-const artists = [
-  {
-    id: 1,
-    name: "Luna Rodriguez",
-    genre: "Pop",
-    tracks: 24,
-    followers: "125K",
-    monthlyStreams: "2.1M",
-    status: "verified",
-    avatar: "LR",
-    growth: "+12%"
-  },
-  {
-    id: 2,
-    name: "The Midnight Echo",
-    genre: "Electronic",
-    tracks: 18,
-    followers: "89K",
-    monthlyStreams: "1.8M",
-    status: "verified",
-    avatar: "TME",
-    growth: "+8%"
-  },
-  {
-    id: 3,
-    name: "Maya Chen",
-    genre: "Indie Rock",
-    tracks: 31,
-    followers: "67K",
-    monthlyStreams: "1.2M",
-    status: "pending",
-    avatar: "MC",
-    growth: "+15%"
-  },
-  {
-    id: 4,
-    name: "Alex Thompson",
-    genre: "Hip-Hop",
-    tracks: 42,
-    followers: "203K",
-    monthlyStreams: "3.4M",
-    status: "verified",
-    avatar: "AT",
-    growth: "+5%"
-  },
-  {
-    id: 5,
-    name: "Sophia Kim",
-    genre: "R&B",
-    tracks: 16,
-    followers: "91K",
-    monthlyStreams: "1.5M",
-    status: "verified",
-    avatar: "SK",
-    growth: "+18%"
-  },
-  {
-    id: 6,
-    name: "River Stone",
-    genre: "Folk",
-    tracks: 28,
-    followers: "45K",
-    monthlyStreams: "890K",
-    status: "pending",
-    avatar: "RS",
-    growth: "+22%"
-  },
-];
 
 export function ArtistsPage() {
   const [searchTerm, setSearchTerm] = useState("");
+  const { data: artists, loading } = useArtists();
 
-  const filteredArtists = artists.filter(artist =>
-    artist.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    artist.genre.toLowerCase().includes(searchTerm.toLowerCase())
+  const filteredArtists = (artists || []).filter(artist =>
+    artist.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    artist.genre?.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
   const getStatusBadge = (status: string) => {
@@ -99,9 +34,9 @@ export function ArtistsPage() {
   };
 
   return (
-    <>
+    <div className="container fade-in space-y-8">
       {/* Header */}
-      <header className="bg-dark-bg border-b border-dark-color px-8 py-6">
+      <header className="bg-dark-bg border-b border-dark-color px-8 py-6 rounded-xl shadow">
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-semibold text-dark-primary">Artists</h1>
@@ -114,7 +49,7 @@ export function ArtistsPage() {
         </div>
       </header>
 
-      <main className="flex-1 overflow-auto p-8 bg-dark-bg">
+      <main className="flex-1 overflow-auto p-8 bg-dark-bg rounded-xl shadow">
         {/* Search and Filters */}
         <div className="mb-8">
           <div className="relative max-w-md">
@@ -130,7 +65,14 @@ export function ArtistsPage() {
 
         {/* Artists Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filteredArtists.map((artist) => (
+          {loading && (
+            <>
+              {[...Array(6)].map((_, i) => (
+                <Skeleton key={i} className="h-40 rounded-xl" />
+              ))}
+            </>
+          )}
+          {!loading && filteredArtists.map((artist) => (
             <div key={artist.id} className="dark-card hover:dark-shadow-lg transition-all duration-300 hover:-translate-y-1">
               <div className="flex items-start justify-between mb-4">
                 <div className="flex items-center space-x-4">
@@ -207,6 +149,6 @@ export function ArtistsPage() {
           ))}
         </div>
       </main>
-    </>
+    </div>
   );
 }

--- a/components/pages/DashboardPage.tsx
+++ b/components/pages/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { Badge } from "../ui/badge";
 import { 
   Upload, 
@@ -90,6 +91,7 @@ export function DashboardPage({ onNavigate }: DashboardPageProps) {
     loading: boolean;
   };
   const { data: verificationRequests, loading: requestsLoading } = useVerificationRequests();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const timer = setTimeout(() => setIsLoading(false), 1200);
@@ -100,12 +102,14 @@ export function DashboardPage({ onNavigate }: DashboardPageProps) {
     if (onNavigate) {
       onNavigate(page);
     }
+    navigate(`/${page.toLowerCase()}`);
   };
 
   const handleVerificationClick = () => {
     if (onNavigate) {
       onNavigate("Verify Artists");
     }
+    navigate("/verify-artists");
   };
 
   if (isLoading) {

--- a/components/pages/PlaylistsPage.tsx
+++ b/components/pages/PlaylistsPage.tsx
@@ -2,83 +2,18 @@ import { useState } from "react";
 import { Search, Plus, Music, Clock, Users, MoreHorizontal, Heart, Play } from "lucide-react";
 import { Input } from "../ui/input";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/dropdown-menu";
+import { usePlaylists } from "../../utils/supabase/hooks";
+import { Skeleton } from "../ui/skeleton";
 
-const playlists = [
-  {
-    id: 1,
-    name: "Today's Hits",
-    description: "The biggest songs right now",
-    tracks: 50,
-    duration: "3h 12m",
-    likes: "24.5K",
-    curator: "StreamVibe Editorial",
-    cover: "🔥",
-    category: "Featured"
-  },
-  {
-    id: 2,
-    name: "Chill Vibes",
-    description: "Relaxing tunes for any moment",
-    tracks: 32,
-    duration: "2h 18m",
-    likes: "18.2K",
-    curator: "StreamVibe Editorial",
-    cover: "🌙",
-    category: "Mood"
-  },
-  {
-    id: 3,
-    name: "Workout Energy",
-    description: "High-energy tracks to keep you moving",
-    tracks: 45,
-    duration: "2h 56m",
-    likes: "31.7K",
-    curator: "Fitness Team",
-    cover: "⚡",
-    category: "Activity"
-  },
-  {
-    id: 4,
-    name: "Indie Discoveries",
-    description: "Fresh indie tracks you need to hear",
-    tracks: 28,
-    duration: "1h 52m",
-    likes: "12.8K",
-    curator: "Music Discovery",
-    cover: "🎸",
-    category: "Genre"
-  },
-  {
-    id: 5,
-    name: "Jazz Classics",
-    description: "Timeless jazz standards",
-    tracks: 37,
-    duration: "3h 24m",
-    likes: "9.4K",
-    curator: "Jazz Lovers",
-    cover: "🎷",
-    category: "Genre"
-  },
-  {
-    id: 6,
-    name: "Study Focus",
-    description: "Instrumental tracks for concentration",
-    tracks: 60,
-    duration: "4h 15m",
-    likes: "22.1K",
-    curator: "Productivity Team",
-    cover: "📚",
-    category: "Activity"
-  },
-];
 
 const categories = ["All", "Featured", "Mood", "Activity", "Genre"];
 
 export function PlaylistsPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("All");
+  const { data: playlists, loading } = usePlaylists();
 
-  const filteredPlaylists = playlists.filter(playlist => {
+  const filteredPlaylists = (playlists || []).filter(playlist => {
     const matchesSearch = playlist.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          playlist.description.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesCategory = selectedCategory === "All" || playlist.category === selectedCategory;
@@ -86,9 +21,9 @@ export function PlaylistsPage() {
   });
 
   return (
-    <>
+    <div className="container fade-in space-y-8">
       {/* Header */}
-      <header className="bg-dark-bg border-b border-dark-color px-8 py-6">
+      <header className="bg-dark-bg border-b border-dark-color px-8 py-6 rounded-xl shadow">
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-semibold text-dark-primary">Playlists</h1>
@@ -101,7 +36,7 @@ export function PlaylistsPage() {
         </div>
       </header>
 
-      <main className="flex-1 overflow-auto p-8 bg-dark-bg">
+      <main className="flex-1 overflow-auto p-8 bg-dark-bg rounded-xl shadow">
         {/* Search and Filters */}
         <div className="mb-8 space-y-4">
           <div className="relative max-w-md">
@@ -134,7 +69,12 @@ export function PlaylistsPage() {
 
         {/* Playlists Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filteredPlaylists.map((playlist) => (
+          {loading && (
+            [...Array(6)].map((_, i) => (
+              <Skeleton key={i} className="h-64 rounded-xl" />
+            ))
+          )}
+          {!loading && filteredPlaylists.map((playlist) => (
             <div key={playlist.id} className="dark-card hover:dark-shadow-lg transition-all duration-300 hover:-translate-y-1 group">
               <div className="relative mb-4">
                 <div className="w-full h-48 bg-gradient-to-br from-purple-600 to-pink-500 rounded-xl flex items-center justify-center relative overflow-hidden">
@@ -211,6 +151,6 @@ export function PlaylistsPage() {
           ))}
         </div>
       </main>
-    </>
+    </div>
   );
 }

--- a/components/pages/UploadsPage.tsx
+++ b/components/pages/UploadsPage.tsx
@@ -3,99 +3,22 @@ import { Search, Filter, Download, Music, Clock, CheckCircle, XCircle, AlertCirc
 import { Input } from "../ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/dropdown-menu";
+import { useTracks } from "../../utils/supabase/hooks";
+import { Skeleton } from "../ui/skeleton";
 
-const uploads = [
-  {
-    id: 1,
-    title: "Midnight Dreams",
-    artist: "Luna Rodriguez",
-    album: "Nocturnal",
-    uploadDate: "2024-01-15",
-    status: "published",
-    duration: "3:42",
-    fileSize: "8.4 MB",
-    format: "MP3",
-    plays: "12.5K",
-    quality: "320kbps"
-  },
-  {
-    id: 2,
-    title: "Electric Soul",
-    artist: "The Midnight Echo",
-    album: "Synthetic",
-    uploadDate: "2024-01-14",
-    status: "processing",
-    duration: "4:18",
-    fileSize: "12.1 MB",
-    format: "FLAC",
-    plays: "0",
-    quality: "Lossless"
-  },
-  {
-    id: 3,
-    title: "Broken Strings",
-    artist: "Maya Chen",
-    album: "Raw Emotions",
-    uploadDate: "2024-01-14",
-    status: "failed",
-    duration: "2:56",
-    fileSize: "6.8 MB",
-    format: "MP3",
-    plays: "0",
-    quality: "256kbps"
-  },
-  {
-    id: 4,
-    title: "Urban Legends",
-    artist: "Alex Thompson",
-    album: "Street Stories",
-    uploadDate: "2024-01-13",
-    status: "published",
-    duration: "3:29",
-    fileSize: "9.2 MB",
-    format: "MP3",
-    plays: "24.1K",
-    quality: "320kbps"
-  },
-  {
-    id: 5,
-    title: "Velvet Nights",
-    artist: "Sophia Kim",
-    album: "Smooth Operator",
-    uploadDate: "2024-01-12",
-    status: "published",
-    duration: "4:05",
-    fileSize: "11.3 MB",
-    format: "FLAC",
-    plays: "18.7K",
-    quality: "Lossless"
-  },
-  {
-    id: 6,
-    title: "Mountain Song",
-    artist: "River Stone",
-    album: "Nature's Call",
-    uploadDate: "2024-01-11",
-    status: "pending",
-    duration: "5:12",
-    fileSize: "14.8 MB",
-    format: "WAV",
-    plays: "0",
-    quality: "Lossless"
-  },
-];
 
 const statusOptions = ["All", "Published", "Processing", "Pending", "Failed"];
 
 export function UploadsPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("All");
+  const { data: uploads, loading } = useTracks();
 
-  const filteredUploads = uploads.filter(upload => {
-    const matchesSearch = 
-      upload.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      upload.artist.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      upload.album.toLowerCase().includes(searchTerm.toLowerCase());
+  const filteredUploads = (uploads || []).filter(upload => {
+    const matchesSearch =
+      upload.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      upload.artist?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      upload.album?.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesStatus = statusFilter === "All" || upload.status === statusFilter.toLowerCase();
     return matchesSearch && matchesStatus;
   });
@@ -132,9 +55,9 @@ export function UploadsPage() {
   };
 
   return (
-    <>
+    <div className="container fade-in space-y-8">
       {/* Header */}
-      <header className="bg-dark-bg border-b border-dark-color px-8 py-6">
+      <header className="bg-dark-bg border-b border-dark-color px-8 py-6 rounded-xl shadow">
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-semibold text-dark-primary">Uploads</h1>
@@ -147,7 +70,7 @@ export function UploadsPage() {
         </div>
       </header>
 
-      <main className="flex-1 overflow-auto p-8 bg-dark-bg">
+      <main className="flex-1 overflow-auto p-8 bg-dark-bg rounded-xl shadow">
         {/* Search and Filters */}
         <div className="mb-8 flex items-center space-x-4">
           <div className="relative flex-1 max-w-md">
@@ -191,7 +114,14 @@ export function UploadsPage() {
                 </tr>
               </thead>
               <tbody>
-                {filteredUploads.map((upload) => (
+                {loading && (
+                  <tr>
+                    <td colSpan={8} className="p-4">
+                      <Skeleton className="h-32 w-full" />
+                    </td>
+                  </tr>
+                )}
+                {!loading && filteredUploads.map((upload) => (
                   <tr key={upload.id} className="border-b border-dark-color hover:bg-dark-table-hover transition-colors">
                     <td className="py-4 px-4">
                       <div className="flex items-center space-x-3">
@@ -265,6 +195,6 @@ export function UploadsPage() {
           </div>
         </div>
       </main>
-    </>
+    </div>
   );
 }

--- a/components/pages/UsersPage.tsx
+++ b/components/pages/UsersPage.tsx
@@ -1,144 +1,53 @@
 import { useState } from "react";
-import { Search, Filter, Download, Music, Clock, CheckCircle, XCircle, AlertCircle, MoreHorizontal } from "lucide-react";
+import { Search, Download, MoreHorizontal, CheckCircle, User as UserIcon } from "lucide-react";
 import { Input } from "../ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/dropdown-menu";
+import { useUsers } from "../../utils/supabase/hooks";
+import { Skeleton } from "../ui/skeleton";
 
-const uploads = [
-  {
-    id: 1,
-    title: "Midnight Dreams",
-    artist: "Luna Rodriguez",
-    album: "Nocturnal",
-    uploadDate: "2024-01-15",
-    status: "published",
-    duration: "3:42",
-    fileSize: "8.4 MB",
-    format: "MP3",
-    plays: "12.5K",
-    quality: "320kbps"
-  },
-  {
-    id: 2,
-    title: "Electric Soul",
-    artist: "The Midnight Echo",
-    album: "Synthetic",
-    uploadDate: "2024-01-14",
-    status: "processing",
-    duration: "4:18",
-    fileSize: "12.1 MB",
-    format: "FLAC",
-    plays: "0",
-    quality: "Lossless"
-  },
-  {
-    id: 3,
-    title: "Broken Strings",
-    artist: "Maya Chen",
-    album: "Raw Emotions",
-    uploadDate: "2024-01-14",
-    status: "failed",
-    duration: "2:56",
-    fileSize: "6.8 MB",
-    format: "MP3",
-    plays: "0",
-    quality: "256kbps"
-  },
-  {
-    id: 4,
-    title: "Urban Legends",
-    artist: "Alex Thompson",
-    album: "Street Stories",
-    uploadDate: "2024-01-13",
-    status: "published",
-    duration: "3:29",
-    fileSize: "9.2 MB",
-    format: "MP3",
-    plays: "24.1K",
-    quality: "320kbps"
-  },
-  {
-    id: 5,
-    title: "Velvet Nights",
-    artist: "Sophia Kim",
-    album: "Smooth Operator",
-    uploadDate: "2024-01-12",
-    status: "published",
-    duration: "4:05",
-    fileSize: "11.3 MB",
-    format: "FLAC",
-    plays: "18.7K",
-    quality: "Lossless"
-  },
-  {
-    id: 6,
-    title: "Mountain Song",
-    artist: "River Stone",
-    album: "Nature's Call",
-    uploadDate: "2024-01-11",
-    status: "pending",
-    duration: "5:12",
-    fileSize: "14.8 MB",
-    format: "WAV",
-    plays: "0",
-    quality: "Lossless"
-  },
-];
 
-const statusOptions = ["All", "Published", "Processing", "Pending", "Failed"];
+
+const statusOptions = ["All", "Admin", "User"];
 
 export function UsersPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("All");
+  const { data: users, loading } = useUsers();
 
-  const filteredUploads = uploads.filter(upload => {
-    const matchesSearch = 
-      upload.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      upload.artist.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      upload.album.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesStatus = statusFilter === "All" || upload.status === statusFilter.toLowerCase();
+  const filteredUsers = (users || []).filter(user => {
+    const matchesSearch =
+      user.email?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      user.user_metadata?.name?.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesStatus =
+      statusFilter === "All" ||
+      (statusFilter === "Admin" ? user.role === "admin" : user.role !== "admin");
     return matchesSearch && matchesStatus;
   });
 
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case "published":
-        return <CheckCircle className="w-4 h-4 text-green-400" />;
-      case "processing":
-        return <Clock className="w-4 h-4 text-blue-400" />;
-      case "pending":
-        return <AlertCircle className="w-4 h-4 text-orange-400" />;
-      case "failed":
-        return <XCircle className="w-4 h-4 text-red-400" />;
-      default:
-        return <Clock className="w-4 h-4 text-gray-400" />;
-    }
+  const getStatusIcon = (role: string) => {
+    return role === "admin" ? (
+      <CheckCircle className="w-4 h-4 text-green-400" />
+    ) : (
+      <UserIcon className="w-4 h-4 text-blue-400" />
+    );
   };
 
-  const getStatusBadge = (status: string) => {
-    const baseClasses = "px-3 py-1 rounded-full text-xs font-medium";
-    switch (status) {
-      case "published":
-        return `${baseClasses} bg-green-600 text-white`;
-      case "processing":
-        return `${baseClasses} bg-blue-600 text-white`;
-      case "pending":
-        return `${baseClasses} bg-orange-600 text-white`;
-      case "failed":
-        return `${baseClasses} bg-red-600 text-white`;
-      default:
-        return `${baseClasses} bg-gray-600 text-white`;
-    }
+  const getStatusBadge = (role: string) => {
+    const base = "px-3 py-1 rounded-full text-xs font-medium";
+    return role === "admin"
+      ? `${base} bg-green-600 text-white`
+      : `${base} bg-blue-600 text-white`;
   };
 
   return (
-    <>
+    <div className="container fade-in space-y-8">
       {/* Header */}
-      <header className="bg-dark-bg border-b border-dark-color px-8 py-6">
+      <header className="bg-dark-bg border-b border-dark-color px-8 py-6 rounded-xl shadow">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-semibold text-dark-primary">Uploads</h1>
-            <p className="text-sm text-dark-secondary mt-1">Track and manage all uploaded content</p>
+            <h1 className="text-2xl font-semibold text-dark-primary">Users</h1>
+            <p className="text-sm text-dark-secondary mt-1">Manage platform users and roles</p>
           </div>
           <button className="dark-button-secondary gap-2 flex items-center">
             <Download className="w-4 h-4" />
@@ -147,13 +56,13 @@ export function UsersPage() {
         </div>
       </header>
 
-      <main className="flex-1 overflow-auto p-8 bg-dark-bg">
+      <main className="flex-1 overflow-auto p-8 bg-dark-bg rounded-xl shadow">
         {/* Search and Filters */}
         <div className="mb-8 flex items-center space-x-4">
           <div className="relative flex-1 max-w-md">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-dark-secondary w-4 h-4" />
             <Input
-              placeholder="Search uploads..."
+              placeholder="Search users..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               className="pl-10 bg-dark-card border-dark-color text-dark-primary"
@@ -174,62 +83,38 @@ export function UsersPage() {
           </Select>
         </div>
 
-        {/* Uploads Table */}
+        {/* Users Table */}
         <div className="dark-card overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-dark-color">
-                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Track</th>
-                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Artist</th>
-                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Upload Date</th>
-                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Status</th>
-                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Duration</th>
-                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Format</th>
-                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Plays</th>
+                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Name</th>
+                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Email</th>
+                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Role</th>
+                  <th className="text-left font-semibold text-dark-primary pb-4 px-4">Joined</th>
                   <th className="text-center font-semibold text-dark-primary pb-4 px-4">Actions</th>
                 </tr>
               </thead>
               <tbody>
-                {filteredUploads.map((upload) => (
-                  <tr key={upload.id} className="border-b border-dark-color hover:bg-dark-table-hover transition-colors">
-                    <td className="py-4 px-4">
-                      <div className="flex items-center space-x-3">
-                        <div className="w-10 h-10 bg-dark-tag rounded-lg flex items-center justify-center">
-                          <Music className="w-4 h-4 text-dark-secondary" />
-                        </div>
-                        <div>
-                          <p className="font-medium text-dark-primary">{upload.title}</p>
-                          <p className="text-xs text-dark-secondary">{upload.album}</p>
-                        </div>
-                      </div>
+                {loading && (
+                  <tr>
+                    <td colSpan={5} className="p-4">
+                      <Skeleton className="h-24 w-full" />
                     </td>
-                    <td className="py-4 px-4 text-dark-primary font-medium">
-                      {upload.artist}
-                    </td>
-                    <td className="py-4 px-4 text-dark-secondary">
-                      {upload.uploadDate}
-                    </td>
+                  </tr>
+                )}
+                {!loading && filteredUsers.map((user) => (
+                  <tr key={user.id} className="border-b border-dark-color hover:bg-dark-table-hover transition-colors">
+                    <td className="py-4 px-4 font-medium text-dark-primary">{user.user_metadata?.name || 'N/A'}</td>
+                    <td className="py-4 px-4 text-dark-secondary">{user.email}</td>
                     <td className="py-4 px-4">
                       <div className="flex items-center space-x-2">
-                        {getStatusIcon(upload.status)}
-                        <span className={getStatusBadge(upload.status)}>
-                          {upload.status.charAt(0).toUpperCase() + upload.status.slice(1)}
-                        </span>
+                        {getStatusIcon(user.role)}
+                        <span className={getStatusBadge(user.role)}>{user.role || 'user'}</span>
                       </div>
                     </td>
-                    <td className="py-4 px-4 text-dark-secondary">
-                      {upload.duration}
-                    </td>
-                    <td className="py-4 px-4">
-                      <div className="text-dark-secondary">
-                        <div>{upload.format}</div>
-                        <div className="text-xs">{upload.quality}</div>
-                      </div>
-                    </td>
-                    <td className="py-4 px-4 text-dark-primary font-medium">
-                      {upload.plays}
-                    </td>
+                    <td className="py-4 px-4 text-dark-secondary">{new Date(user.created_at).toLocaleDateString()}</td>
                     <td className="py-4 px-4 text-center">
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
@@ -238,23 +123,9 @@ export function UsersPage() {
                           </button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent className="bg-dark-card border-dark-color">
-                          <DropdownMenuItem className="text-dark-primary hover:bg-dark-hover">
-                            View Details
-                          </DropdownMenuItem>
-                          <DropdownMenuItem className="text-dark-primary hover:bg-dark-hover">
-                            Edit Metadata
-                          </DropdownMenuItem>
-                          <DropdownMenuItem className="text-dark-primary hover:bg-dark-hover">
-                            Download
-                          </DropdownMenuItem>
-                          {upload.status === "failed" && (
-                            <DropdownMenuItem className="text-blue-400 hover:bg-dark-hover">
-                              Retry Upload
-                            </DropdownMenuItem>
-                          )}
-                          <DropdownMenuItem className="text-red-400 hover:bg-dark-hover">
-                            Delete
-                          </DropdownMenuItem>
+                          <DropdownMenuItem className="text-dark-primary hover:bg-dark-hover">View</DropdownMenuItem>
+                          <DropdownMenuItem className="text-dark-primary hover:bg-dark-hover">Edit</DropdownMenuItem>
+                          <DropdownMenuItem className="text-red-400 hover:bg-dark-hover">Delete</DropdownMenuItem>
                         </DropdownMenuContent>
                       </DropdownMenu>
                     </td>
@@ -265,6 +136,6 @@ export function UsersPage() {
           </div>
         </div>
       </main>
-    </>
+    </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -657,3 +657,6 @@ a:hover {
 .mb-4  { margin-bottom: 1rem; }
 .p-4   { padding: 1rem; }
 .p-6   { padding: 1.5rem; }
+
+/* Fade-in animation */
+.fade-in{opacity:0;animation:fadeIn 0.5s forwards;}@keyframes fadeIn{to{opacity:1}}


### PR DESCRIPTION
## Summary
- drop local mock data for artists, playlists, uploads and users
- fetch live data from Supabase using hooks
- add fade‑in utility and wrap pages with a container
- wire dashboard quick actions to navigate using `useNavigate`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a72f12ccc8324b8e5da1a42d8b8be