### PR TITLE
Fix supabase env handling and styling

### DIFF
--- a/app/actions/upload.ts
+++ b/app/actions/upload.ts
@@ -2,9 +2,13 @@
 
 import slugify from 'slugify'
 import { supabaseAdmin } from '../../utils/supabase/serverClient'
+import { supabaseBrowser } from '../../utils/supabase/supabaseClient'
+
+const getSupabase = () =>
+  typeof window === 'undefined' ? supabaseAdmin() : supabaseBrowser()
 
 export async function uploadSingleAction(formData: FormData) {
-  const supabase = supabaseAdmin()
+  const supabase = getSupabase()
   const title = formData.get('title') as string
   const artist = formData.get('artist') as string
   const genre = formData.get('genre') as string
@@ -59,7 +63,7 @@ export async function uploadSingleAction(formData: FormData) {
 }
 
 export async function uploadAlbumAction(formData: FormData) {
-  const supabase = supabaseAdmin()
+  const supabase = getSupabase()
   const title = formData.get('title') as string
   const artist = formData.get('artist') as string
   const genre = formData.get('genre') as string

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 }

--- a/utils/supabase/serverClient.ts
+++ b/utils/supabase/serverClient.ts
@@ -1,10 +1,19 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+export const supabaseAdmin = () => {
+  if (typeof window !== 'undefined') {
+    throw new Error('supabaseAdmin can only be used on the server');
+  }
 
-if (!supabaseUrl || !serviceRoleKey) {
-  throw new Error("Supabase server environment variables are not set");
-}
+  const supabaseUrl =
+    process.env.VITE_SUPABASE_URL || import.meta.env.VITE_SUPABASE_URL;
+  const serviceRoleKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    (import.meta as any).env.SUPABASE_SERVICE_ROLE_KEY;
 
-export const supabaseAdmin = () => createClient(supabaseUrl, serviceRoleKey);
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Supabase server environment variables are not set');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey);
+};


### PR DESCRIPTION
## Summary
- use the standard `tailwindcss` plugin so postcss builds global styles correctly
- fallback to `import.meta.env` when creating the Supabase server client

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688b2e6eba408324a49184cb55839c94