### PR TITLE
Improve layout and add theme toggle

### DIFF
--- a/components/common/ThemeToggle.tsx
+++ b/components/common/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+
+export function ThemeToggle() {
+  const [dark, setDark] = useState(() => {
+    if (typeof window === "undefined") return true;
+    const t = localStorage.getItem("theme");
+    if (t) return t === "dark";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  });
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark);
+    localStorage.setItem("theme", dark ? "dark" : "light");
+  }, [dark]);
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={() => setDark(!dark)}
+      className="rounded-md p-2 transition-colors hover:bg-muted"
+    >
+      {dark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </button>
+  );
+}

--- a/components/layout/AdminLayout.tsx
+++ b/components/layout/AdminLayout.tsx
@@ -19,6 +19,7 @@ import {
   Settings,
   Crown,
 } from "lucide-react";
+import { ThemeToggle } from "../common/ThemeToggle";
 
 const navigationItems = [
   { icon: BarChart3, label: "Dashboard", path: "/", color: "text-purple-400" },
@@ -95,7 +96,7 @@ export function AdminLayout() {
   };
 
   return (
-    <div className="flex h-screen bg-slate-950 overflow-hidden">
+    <div className="flex h-screen bg-background overflow-hidden">
       {/* Mobile Overlay */}
       {mobileMenuOpen && (
         <div 
@@ -203,6 +204,7 @@ export function AdminLayout() {
                 {session?.user?.email?.charAt(0).toUpperCase()}
               </span>
             </div>
+            <ThemeToggle />
           </div>
         </div>
 
@@ -217,6 +219,7 @@ export function AdminLayout() {
               <Wifi className="w-4 h-4 mr-2" />
               Connected to Supabase
             </Badge>
+            <ThemeToggle />
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -5,8 +5,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sonix Admin</title>
+    <script>
+      const t = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (t === 'dark' || (!t && prefersDark)) document.documentElement.classList.add('dark');
+    </script>
   </head>
-  <body class="bg-sonix-black">
+  <body class="min-h-screen bg-background">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/styles/glassmorphism.css
+++ b/styles/glassmorphism.css
@@ -837,13 +837,16 @@
    ============================================================================= */
 
 .glass-page {
-  padding: 2rem 1rem;
-  max-width: 1280px;
+  padding: 2rem;
+  max-width: 1200px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .glass-panel {
-  padding: 1.5rem;
+  padding: 1.75rem;
   border-radius: 1rem;
   background: rgba(26, 26, 29, 0.6);
   backdrop-filter: blur(10px);
@@ -854,6 +857,7 @@
   opacity: 0;
   transform: translateY(10px);
   animation: glassFadeInUp 0.6s ease forwards;
+  margin-bottom: 1rem;
 }
 
 @keyframes glassFadeInUp {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -42,21 +42,64 @@ button {
 
 :root {
   --font-size: 14px;
-  
-  /* Sonix Color Palette */
-  --sonix-black: #0E0E10;
-  --sonix-dark-card: #1A1A1D;
-  --sonix-primary-text: #FFFFFF;
-  --sonix-secondary-text: #A1A1AA;
-  --sonix-electric-purple: #8B5CF6;
-  --sonix-neon-green: #10B981;
-  --sonix-error-red: #EF4444;
-  --sonix-tag: #27272A;
-  --sonix-hover: #2A2A2D;
-  --sonix-table-hover: #1F1F23;
-  --sonix-border: #3F3F46;
-  
-  /* Updated theme variables for Sonix */
+
+  /* Light theme palette */
+  --sonix-black: #f9fafb;
+  --sonix-dark-card: #ffffff;
+  --sonix-primary-text: #0e0e10;
+  --sonix-secondary-text: #475569;
+  --sonix-electric-purple: #8b5cf6;
+  --sonix-neon-green: #10b981;
+  --sonix-error-red: #ef4444;
+  --sonix-tag: #e2e8f0;
+  --sonix-hover: #f1f5f9;
+  --sonix-table-hover: #f8fafc;
+  --sonix-border: #d1d5db;
+
+  --background: #f9fafb;
+  --foreground: #0e0e10;
+  --card: #ffffff;
+  --card-foreground: #0e0e10;
+  --popover: #ffffff;
+  --popover-foreground: #0e0e10;
+  --primary: #8b5cf6;
+  --primary-foreground: #ffffff;
+  --secondary: #f1f5f9;
+  --secondary-foreground: #0e0e10;
+  --muted: #f1f5f9;
+  --muted-foreground: #475569;
+  --accent: #8b5cf6;
+  --accent-foreground: #ffffff;
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
+  --border: #d1d5db;
+  --input: #ffffff;
+  --input-background: #ffffff;
+  --switch-background: #e5e7eb;
+  --font-weight-medium: 600;
+  --font-weight-normal: 400;
+  --ring: #8b5cf6;
+
+  /* Chart colors */
+  --chart-1: #8b5cf6;
+  --chart-2: #10b981;
+  --chart-3: #64748b;
+  --chart-4: #f59e0b;
+  --chart-5: #ef4444;
+
+  --radius: 0.75rem;
+
+  --sidebar: #f9fafb;
+  --sidebar-foreground: #0e0e10;
+  --sidebar-primary: #0e0e10;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #8b5cf6;
+  --sidebar-accent-foreground: #ffffff;
+  --sidebar-border: #d1d5db;
+  --sidebar-ring: #8b5cf6;
+}
+
+.dark {
   --background: #0E0E10;
   --foreground: #FFFFFF;
   --card: #1A1A1D;
@@ -77,20 +120,12 @@ button {
   --input: #1A1A1D;
   --input-background: #1A1A1D;
   --switch-background: #3F3F46;
-  --font-weight-medium: 600;
-  --font-weight-normal: 400;
   --ring: #8B5CF6;
-  
-  /* Chart colors using Sonix theme */
   --chart-1: #8B5CF6;
   --chart-2: #10B981;
   --chart-3: #A1A1AA;
   --chart-4: #F59E0B;
   --chart-5: #EF4444;
-  
-  --radius: 0.75rem;
-  
-  /* Sidebar colors for Sonix theme */
   --sidebar: #0E0E10;
   --sidebar-foreground: #FFFFFF;
   --sidebar-primary: #FFFFFF;
@@ -99,6 +134,17 @@ button {
   --sidebar-accent-foreground: #FFFFFF;
   --sidebar-border: #3F3F46;
   --sidebar-ring: #8B5CF6;
+  --sonix-black: #0E0E10;
+  --sonix-dark-card: #1A1A1D;
+  --sonix-primary-text: #FFFFFF;
+  --sonix-secondary-text: #A1A1AA;
+  --sonix-electric-purple: #8B5CF6;
+  --sonix-neon-green: #10B981;
+  --sonix-error-red: #EF4444;
+  --sonix-tag: #27272A;
+  --sonix-hover: #2A2A2D;
+  --sonix-table-hover: #1F1F23;
+  --sonix-border: #3F3F46;
 }
 
 @theme inline {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ export default {
     "./utils/**/*.{js,ts,jsx,tsx}",
     "./styles/**/*.{css,scss}",
   ],
+  darkMode: "class",
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind
- add light and dark variables in global styles
- add a script to apply saved theme on page load
- include theme toggle component in admin layout
- refine page and panel spacing

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688b3906172c83249e0f99b6d83cf989