### PR TITLE
refactor: apply glass cards and collapsible layout

### DIFF
--- a/components/common/LoginModal.tsx
+++ b/components/common/LoginModal.tsx
@@ -14,36 +14,54 @@ interface LoginModalProps {
    * Defaults to `false` which keeps the modal closed until the trigger is used.
    */
   defaultOpen?: boolean;
+  /**
+   * Hide the trigger button when the modal should appear immediately.
+   */
+  showTrigger?: boolean;
 }
 
-export function LoginModal({ defaultOpen = false }: LoginModalProps) {
+export function LoginModal({ defaultOpen = false, showTrigger = true }: LoginModalProps) {
   const [open, setOpen] = useState(defaultOpen);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger className="px-4 py-2 rounded-md bg-white/10 text-white hover:bg-white/20 transition">
-        Login
-      </DialogTrigger>
-      <DialogContent className="w-full max-w-sm rounded-2xl border border-white/20 bg-white/10 p-6 backdrop-blur-xl shadow-lg text-white sm:max-w-md">
+      {showTrigger && (
+        <DialogTrigger className="rounded-md bg-white/10 px-4 py-2 text-white transition hover:bg-white/20">
+          Login
+        </DialogTrigger>
+      )}
+      <DialogContent className="w-full max-w-sm rounded-2xl border border-white/20 bg-white/10 p-6 text-white shadow-lg backdrop-blur-xl sm:max-w-md">
         <DialogHeader>
-          <DialogTitle className="text-2xl font-semibold text-center">
+          <DialogTitle className="text-center text-2xl font-semibold">
             Sign In
           </DialogTitle>
         </DialogHeader>
         <form className="mt-4 space-y-4">
-          <Input
-            type="text"
-            placeholder="Username"
-            className="bg-white/20 border-white/30 placeholder-white/70 text-white"
-          />
-          <Input
-            type="password"
-            placeholder="Password"
-            className="bg-white/20 border-white/30 placeholder-white/70 text-white"
-          />
+          <div className="space-y-2">
+            <label htmlFor="username" className="sr-only">
+              Username
+            </label>
+            <Input
+              id="username"
+              type="text"
+              placeholder="Username"
+              className="border-white/30 bg-white/20 text-white placeholder-white/70"
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="password" className="sr-only">
+              Password
+            </label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="Password"
+              className="border-white/30 bg-white/20 text-white placeholder-white/70"
+            />
+          </div>
           <button
             type="submit"
-            className="w-full rounded-lg border border-white/30 bg-white/30 px-4 py-2 text-white backdrop-blur-sm transition hover:bg-white/40"
+            className="w-full rounded-lg border border-white/30 bg-white/30 px-4 py-2 text-white backdrop-blur-sm transition hover:bg-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
           >
             Submit
           </button>

--- a/components/layout/AdminLayout.tsx
+++ b/components/layout/AdminLayout.tsx
@@ -55,10 +55,10 @@ export function AdminLayout() {
 
   return (
     <SidebarProvider className="flex min-h-screen bg-background text-foreground">
-      <Sidebar className="border-r border-border bg-sidebar">
+      <Sidebar collapsible="icon" className="border-r border-border bg-sidebar transition-all duration-300">
         <SidebarHeader className="flex items-center justify-between">
           <h1 className="px-2 text-xl font-semibold">Sonix Admin</h1>
-          <SidebarTrigger className="md:hidden" />
+          <SidebarTrigger />
         </SidebarHeader>
         <SidebarContent>
           <SidebarMenu>
@@ -87,6 +87,7 @@ export function AdminLayout() {
       <SidebarRail className="bg-sidebar" />
       <SidebarInset className="flex flex-col">
         <header className="flex h-14 shrink-0 items-center gap-4 border-b px-4">
+          <SidebarTrigger className="lg:hidden" />
           <h2 className="text-lg font-semibold">Sonix Admin</h2>
           <div className="ml-auto flex items-center gap-2">
             <Input

--- a/components/pages/LoginPage.tsx
+++ b/components/pages/LoginPage.tsx
@@ -2,8 +2,8 @@ import { LoginModal } from "../common/LoginModal";
 
 export function LoginPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-4">
-      <LoginModal defaultOpen />
-    </div>
+    <main className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <LoginModal defaultOpen showTrigger={false} />
+    </main>
   );
 }

--- a/components/pages/UploadPage.tsx
+++ b/components/pages/UploadPage.tsx
@@ -10,12 +10,15 @@ export function UploadPage() {
   const navigate = useNavigate()
 
   return (
-    <main className="glass-page space-y-6">
-      <button onClick={() => navigate(-1)} className="glass-back-button mb-4">
+    <main className="space-y-6 p-6">
+      <button
+        onClick={() => navigate(-1)}
+        className="mb-4 rounded-md bg-white/10 px-4 py-2 text-white transition hover:bg-white/20"
+      >
         ← Back
       </button>
       <Tabs value={tab} onValueChange={setTab} className="space-y-4">
-        <TabsList>
+        <TabsList className="grid w-full grid-cols-2">
           <TabsTrigger value="single">Single</TabsTrigger>
           <TabsTrigger value="album">Album</TabsTrigger>
         </TabsList>

--- a/components/upload/UploadAlbumForm.tsx
+++ b/components/upload/UploadAlbumForm.tsx
@@ -3,6 +3,7 @@ import { uploadAlbumAction } from '../../app/actions/upload'
 import { supabaseBrowser } from '../../utils/supabase/supabaseClient'
 import { Input } from '../ui/input'
 import { Textarea } from '../ui/textarea'
+import { GlassCard } from '../common/GlassCard'
 
 interface Track {
   title: string
@@ -68,71 +69,103 @@ export default function UploadAlbumForm() {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      {message && <p className="text-sm">{message}</p>}
-      <div className="sonix-form-field">
-        <label>Album Title</label>
-        <Input value={title} onChange={e => setTitle(e.target.value)} required />
-      </div>
-      <div className="sonix-form-field">
-        <label>Artist</label>
-        <input list="album-artists" value={artist} onChange={e => setArtist(e.target.value)} className="w-full border rounded px-2 py-1" />
-        <datalist id="album-artists">
-          {artists.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
-        </datalist>
-      </div>
-      <div className="sonix-form-field">
-        <label>Cover</label>
-        <input type="file" accept="image/*" onChange={e => setCover(e.target.files?.[0] || null)} />
-      </div>
-      <div className="sonix-form-field">
-        <label>Release Date</label>
-        <Input type="date" value={releaseDate} onChange={e => setReleaseDate(e.target.value)} />
-      </div>
-      <div className="sonix-form-field">
-        <label>Genre</label>
-        <Input value={genre} onChange={e => setGenre(e.target.value)} />
-      </div>
-      <div className="sonix-form-field">
-        <label>Description</label>
-        <Textarea value={description} onChange={e => setDescription(e.target.value)} />
-      </div>
-      <div className="sonix-form-field">
-        <label>Album ID</label>
-        <Input value={albumId} onChange={e => setAlbumId(e.target.value)} />
-      </div>
-      <div className="sonix-form-field">
-        <label className="flex items-center gap-2">
-          <input type="checkbox" checked={published} onChange={e => setPublished(e.target.checked)} /> Published
-        </label>
-      </div>
-      <div className="space-y-4">
-        {tracks.map((t, idx) => (
-          <div key={idx} className="p-4 border rounded space-y-2">
-            <div className="sonix-form-field">
-              <label>Track Title</label>
-              <Input value={t.title} onChange={e => updateTrack(idx, 'title', e.target.value)} required />
+    <GlassCard className="p-6">
+      <form onSubmit={onSubmit} className="space-y-4">
+        {message && <p className="text-sm">{message}</p>}
+        <div className="space-y-2">
+          <label htmlFor="albumTitle" className="text-sm font-medium">Album Title</label>
+          <Input id="albumTitle" value={title} onChange={e => setTitle(e.target.value)} required />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="albumArtist" className="text-sm font-medium">Artist</label>
+          <input
+            id="albumArtist"
+            list="album-artists"
+            value={artist}
+            onChange={e => setArtist(e.target.value)}
+            className="w-full rounded-md border border-white/20 bg-white/10 px-3 py-2 text-white"
+          />
+          <datalist id="album-artists">
+            {artists.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+          </datalist>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="cover" className="text-sm font-medium">Cover</label>
+          <input
+            id="cover"
+            type="file"
+            accept="image/*"
+            onChange={e => setCover(e.target.files?.[0] || null)}
+            className="w-full text-sm"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="releaseDate" className="text-sm font-medium">Release Date</label>
+          <Input id="releaseDate" type="date" value={releaseDate} onChange={e => setReleaseDate(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="genre" className="text-sm font-medium">Genre</label>
+          <Input id="genre" value={genre} onChange={e => setGenre(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="description" className="text-sm font-medium">Description</label>
+          <Textarea id="description" value={description} onChange={e => setDescription(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="albumId" className="text-sm font-medium">Album ID</label>
+          <Input id="albumId" value={albumId} onChange={e => setAlbumId(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 text-sm font-medium">
+            <input
+              type="checkbox"
+              checked={published}
+              onChange={e => setPublished(e.target.checked)}
+              className="h-4 w-4"
+            />
+            Published
+          </label>
+        </div>
+        <div className="space-y-4">
+          {tracks.map((t, idx) => (
+            <div key={idx} className="space-y-4 rounded-lg border border-white/20 p-4">
+              <div className="space-y-2">
+                <label htmlFor={`track-title-${idx}`} className="text-sm font-medium">Track Title</label>
+                <Input id={`track-title-${idx}`} value={t.title} onChange={e => updateTrack(idx, 'title', e.target.value)} required />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor={`track-audio-${idx}`} className="text-sm font-medium">Audio</label>
+                <input
+                  id={`track-audio-${idx}`}
+                  type="file"
+                  accept="audio/*"
+                  onChange={e => e.target.files && handleTrackFile(idx, e.target.files[0])}
+                  required
+                  className="w-full text-sm"
+                />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor={`track-lyrics-${idx}`} className="text-sm font-medium">Lyrics</label>
+                <Textarea id={`track-lyrics-${idx}`} value={t.lyrics} onChange={e => updateTrack(idx, 'lyrics', e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor={`track-featured-${idx}`} className="text-sm font-medium">Featured Artists</label>
+                <Input id={`track-featured-${idx}`} value={t.featuredArtists} onChange={e => updateTrack(idx, 'featuredArtists', e.target.value)} />
+              </div>
+              {tracks.length > 1 && (
+                <button type="button" className="text-sm" onClick={() => removeTrack(idx)}>Remove</button>
+              )}
             </div>
-            <div className="sonix-form-field">
-              <label>Audio</label>
-              <input type="file" accept="audio/*" onChange={e => e.target.files && handleTrackFile(idx, e.target.files[0])} required />
-            </div>
-            <div className="sonix-form-field">
-              <label>Lyrics</label>
-              <Textarea value={t.lyrics} onChange={e => updateTrack(idx, 'lyrics', e.target.value)} />
-            </div>
-            <div className="sonix-form-field">
-              <label>Featured Artists</label>
-              <Input value={t.featuredArtists} onChange={e => updateTrack(idx, 'featuredArtists', e.target.value)} />
-            </div>
-            {tracks.length > 1 && (
-              <button type="button" className="text-sm" onClick={() => removeTrack(idx)}>Remove</button>
-            )}
-          </div>
-        ))}
-        <button type="button" className="text-sm" onClick={addTrack}>Add Track</button>
-      </div>
-      <button disabled={pending} className="sonix-button-primary">Upload Album</button>
-    </form>
+          ))}
+          <button type="button" className="text-sm" onClick={addTrack}>Add Track</button>
+        </div>
+        <button
+          disabled={pending}
+          className="rounded-lg bg-white/10 px-4 py-2 text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:opacity-50"
+        >
+          Upload Album
+        </button>
+      </form>
+    </GlassCard>
   )
 }

--- a/components/upload/UploadSingleForm.tsx
+++ b/components/upload/UploadSingleForm.tsx
@@ -3,7 +3,7 @@ import { uploadSingleAction } from '../../app/actions/upload'
 import { supabaseBrowser } from '../../utils/supabase/supabaseClient'
 import { Input } from '../ui/input'
 import { Textarea } from '../ui/textarea'
-import { GlassForm } from '../common/GlassCard'
+import { GlassCard } from '../common/GlassCard'
 import { toast } from 'sonner'
 
 export default function UploadSingleForm() {
@@ -80,81 +80,113 @@ export default function UploadSingleForm() {
   }
 
   return (
-    <GlassForm onSubmit={onSubmit} className="space-y-6 text-lg">
-      <div className="sonix-form-field">
-        <label>Title</label>
-        <Input value={title} onChange={e => setTitle(e.target.value)} required />
-      </div>
-      <div className="sonix-form-field">
-        <label>Artist</label>
-        <input list="artists" value={artist} onChange={e => setArtist(e.target.value)} className="w-full border rounded px-2 py-1" />
-        <datalist id="artists">
-          {artists.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
-        </datalist>
-      </div>
-      <div className="sonix-form-field">
-        <label>Audio File</label>
-        <input type="file" accept="audio/*" onChange={e => e.target.files && handleAudio(e.target.files[0])} required />
-      </div>
-      <div className="sonix-form-field">
-        <label>Cover Art</label>
-        <input type="file" accept="image/*" onChange={e => setCover(e.target.files?.[0] || null)} />
-      </div>
-      <div className="sonix-form-field">
-        <label>Genre</label>
-        <select
-          value={genre}
-          onChange={e => setGenre(e.target.value)}
-          className="w-full border rounded px-3 py-2 bg-dark-card text-dark-primary"
+    <GlassCard className="p-6">
+      <form onSubmit={onSubmit} className="space-y-4 text-lg">
+        <div className="space-y-2">
+          <label htmlFor="title" className="text-sm font-medium">Title</label>
+          <Input id="title" value={title} onChange={e => setTitle(e.target.value)} required />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="artist" className="text-sm font-medium">Artist</label>
+          <input
+            id="artist"
+            list="artists"
+            value={artist}
+            onChange={e => setArtist(e.target.value)}
+            className="w-full rounded-md border border-white/20 bg-white/10 px-3 py-2 text-white"
+          />
+          <datalist id="artists">
+            {artists.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+          </datalist>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="audio" className="text-sm font-medium">Audio File</label>
+          <input
+            id="audio"
+            type="file"
+            accept="audio/*"
+            onChange={e => e.target.files && handleAudio(e.target.files[0])}
+            required
+            className="w-full text-sm"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="cover" className="text-sm font-medium">Cover Art</label>
+          <input
+            id="cover"
+            type="file"
+            accept="image/*"
+            onChange={e => setCover(e.target.files?.[0] || null)}
+            className="w-full text-sm"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="genre" className="text-sm font-medium">Genre</label>
+          <select
+            id="genre"
+            value={genre}
+            onChange={e => setGenre(e.target.value)}
+            className="w-full rounded-md border border-white/20 bg-white/10 px-3 py-2 text-white"
+          >
+            <option value="">Select genre</option>
+            <option>Hip-Hop</option>
+            <option>R&B</option>
+            <option>EDM</option>
+            <option>Rock</option>
+            <option>Pop</option>
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="mood" className="text-sm font-medium">Mood</label>
+          <select
+            id="mood"
+            value={mood}
+            onChange={e => setMood(e.target.value)}
+            className="w-full rounded-md border border-white/20 bg-white/10 px-3 py-2 text-white"
+          >
+            <option value="">Select mood</option>
+            <option>Hype</option>
+            <option>Chill</option>
+            <option>Romantic</option>
+            <option>Dark</option>
+            <option>Uplifting</option>
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="description" className="text-sm font-medium">Description</label>
+          <Textarea id="description" value={description} onChange={e => setDescription(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="lyrics" className="text-sm font-medium">Lyrics</label>
+          <Textarea id="lyrics" value={lyrics} onChange={e => setLyrics(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="releaseDate" className="text-sm font-medium">Release Date</label>
+          <Input id="releaseDate" type="date" value={releaseDate} onChange={e => setReleaseDate(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="featuredArtists" className="text-sm font-medium">Featured Artists</label>
+          <Input id="featuredArtists" value={featuredArtists} onChange={e => setFeaturedArtists(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 text-sm font-medium">
+            <input
+              type="checkbox"
+              checked={published}
+              onChange={e => setPublished(e.target.checked)}
+              className="h-4 w-4"
+            />
+            Published
+          </label>
+        </div>
+        <button
+          disabled={pending}
+          className="flex items-center gap-2 rounded-lg bg-white/10 px-4 py-2 text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:opacity-50"
         >
-          <option value="">Select genre</option>
-          <option>Hip-Hop</option>
-          <option>R&B</option>
-          <option>EDM</option>
-          <option>Rock</option>
-          <option>Pop</option>
-        </select>
-      </div>
-      <div className="sonix-form-field">
-        <label>Mood</label>
-        <select
-          value={mood}
-          onChange={e => setMood(e.target.value)}
-          className="w-full border rounded px-3 py-2 bg-dark-card text-dark-primary"
-        >
-          <option value="">Select mood</option>
-          <option>Hype</option>
-          <option>Chill</option>
-          <option>Romantic</option>
-          <option>Dark</option>
-          <option>Uplifting</option>
-        </select>
-      </div>
-      <div className="sonix-form-field">
-        <label>Description</label>
-        <Textarea value={description} onChange={e => setDescription(e.target.value)} />
-      </div>
-      <div className="sonix-form-field">
-        <label>Lyrics</label>
-        <Textarea value={lyrics} onChange={e => setLyrics(e.target.value)} />
-      </div>
-      <div className="sonix-form-field">
-        <label>Release Date</label>
-        <Input type="date" value={releaseDate} onChange={e => setReleaseDate(e.target.value)} />
-      </div>
-      <div className="sonix-form-field">
-        <label>Featured Artists</label>
-        <Input value={featuredArtists} onChange={e => setFeaturedArtists(e.target.value)} />
-      </div>
-      <div className="sonix-form-field">
-        <label className="flex items-center gap-2">
-          <input type="checkbox" checked={published} onChange={e => setPublished(e.target.checked)} /> Published
-        </label>
-      </div>
-      <button disabled={pending} className="sonix-button-primary flex items-center gap-2">
-        {pending && <span className="h-4 w-4 border-2 border-t-transparent rounded-full animate-spin" />}
-        Upload
-      </button>
-    </GlassForm>
+          {pending && <span className="h-4 w-4 animate-spin rounded-full border-2 border-t-transparent" />}
+          Upload
+        </button>
+      </form>
+    </GlassCard>
   )
 }


### PR DESCRIPTION
## Summary
- use LoginModal directly on login page and support trigger-less launch
- wrap upload forms in GlassCard with consistent spacing and labels
- convert admin layout sidebar to a collapsible, animated navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688f76168458832482909913584147bc