### PR TITLE
feat: add album upload workflow

### DIFF
--- a/app/actions/upload.ts
+++ b/app/actions/upload.ts
@@ -134,9 +134,3 @@ export async function uploadArtistAction(
   return { success: true, data }
 }
 
-// Placeholder album upload action to satisfy imports.
-export async function uploadAlbumAction(
-  _formData: FormData,
-): Promise<{ success: boolean; error?: string }> {
-  return { success: false, error: 'uploadAlbumAction not implemented' }
-}

--- a/app/actions/uploadAlbumAction.ts
+++ b/app/actions/uploadAlbumAction.ts
@@ -1,0 +1,119 @@
+'use server'
+
+import { supabaseAdmin } from '../../utils/supabase/serverClient'
+import { supabaseBrowser } from '../../utils/supabase/supabaseClient'
+
+const getSupabase = () =>
+  typeof window === 'undefined' ? supabaseAdmin() : supabaseBrowser()
+
+export async function uploadAlbumAction(
+  formData: FormData
+): Promise<{ success: boolean; message?: string }> {
+  const supabase = getSupabase()
+  const { data: authData, error: authError } = await supabase.auth.getUser()
+  if (authError) {
+    console.error('Auth fetch error:', authError.message)
+    return { success: false, message: authError.message }
+  }
+  const userId = authData?.user?.id || null
+
+  const title = formData.get('title') as string
+  const artistId = formData.get('main_artist_id') as string
+  const releaseDate = formData.get('releaseDate') as string
+  const coverFile = formData.get('cover') as File | null
+  const tracksMeta = JSON.parse(formData.get('tracks') as string) as Array<{
+    title: string
+    lyrics: string
+    featuredArtists: string
+  }>
+
+  // create empty album row to get id
+  const { data: albumData, error: albumError } = await supabase
+    .from('albums')
+    .insert({
+      title,
+      artist_id: artistId,
+      release_date: releaseDate || null,
+      created_by: userId,
+    })
+    .select('id')
+    .single()
+  if (albumError) {
+    console.error('Album insert error:', albumError.message)
+    return { success: false, message: albumError.message }
+  }
+  const albumId = albumData.id
+
+  // upload cover art using album id
+  let coverUrl: string | null = null
+  if (coverFile) {
+    const ext = coverFile.name.split('.').pop() || 'jpg'
+    const path = `covers/${albumId}.${ext}`
+    const { data: coverData, error: coverError } = await supabase.storage
+      .from('images')
+      .upload(path, coverFile, { upsert: true })
+    if (coverError) {
+      console.error('Cover upload error:', coverError.message)
+      return { success: false, message: coverError.message }
+    }
+    coverUrl = coverData.path
+    const { error: updateError } = await supabase
+      .from('albums')
+      .update({ cover_url: coverUrl })
+      .eq('id', albumId)
+    if (updateError) {
+      console.error('Album cover update error:', updateError.message)
+      return { success: false, message: updateError.message }
+    }
+  }
+
+  // insert tracks and upload audio files in parallel
+  try {
+    await Promise.all(
+      tracksMeta.map(async (meta, index) => {
+        const featuredIds = meta.featuredArtists
+          ? meta.featuredArtists.split(',').map(id => id.trim()).filter(Boolean)
+          : null
+
+        // insert track row to get id
+        const { data: trackData, error: trackInsertError } = await supabase
+          .from('tracks')
+          .insert({
+            title: meta.title,
+            lyrics: meta.lyrics,
+            featured_artist_ids: featuredIds,
+            album_id: albumId,
+            track_number: index + 1,
+            cover_url: coverUrl,
+            created_by: userId,
+          })
+          .select('id')
+          .single()
+        if (trackInsertError) throw new Error(trackInsertError.message)
+        const trackId = trackData.id
+
+        // upload audio file
+        const file = formData.get(`trackFile${index}`) as File | null
+        if (!file) return
+        const ext = file.name.split('.').pop() || 'mp3'
+        const audioPath = `track/${albumId}/${trackId}.${ext}`
+        const { data: audioData, error: audioError } = await supabase.storage
+          .from('audio-files')
+          .upload(audioPath, file, { upsert: true })
+        if (audioError) throw new Error(audioError.message)
+
+        const { error: audioUpdateError } = await supabase
+          .from('tracks')
+          .update({ audio_url: audioData.path })
+          .eq('id', trackId)
+        if (audioUpdateError) throw new Error(audioUpdateError.message)
+      })
+    )
+  } catch (err: any) {
+    console.error('Track upload error:', err.message)
+    return { success: false, message: err.message }
+  }
+
+  return { success: true }
+}
+

--- a/components/upload/UploadAlbumForm.tsx
+++ b/components/upload/UploadAlbumForm.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useTransition } from 'react'
-import { uploadAlbumAction } from '../../app/actions/upload'
+import { useState, useEffect } from 'react'
+import { useAlbumUpload } from './useAlbumUpload'
 import { supabaseBrowser } from '../../utils/supabase/supabaseClient'
 import { Input } from '../ui/input'
 import { Textarea } from '../ui/textarea'
 import { GlassCard } from '../common/GlassCard'
+import { toast } from 'sonner'
 
 interface Track {
   title: string
@@ -19,8 +20,7 @@ export default function UploadAlbumForm() {
   const [cover, setCover] = useState<File | null>(null)
   const [releaseDate, setReleaseDate] = useState('')
   const [tracks, setTracks] = useState<Track[]>([{ title: '', file: null, lyrics: '', featuredArtists: '' }])
-  const [message, setMessage] = useState('')
-  const [pending, startTransition] = useTransition()
+  const { uploadAlbum, pending } = useAlbumUpload()
 
   useEffect(() => {
     supabaseBrowser().from('artists').select('id,name').then(({ data }) => setArtists(data || []))
@@ -45,28 +45,39 @@ export default function UploadAlbumForm() {
     setTracks([{ title: '', file: null, lyrics: '', featuredArtists: '' }])
   }
 
-  const onSubmit = (e: React.FormEvent) => {
+  const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const fd = new FormData()
     fd.append('title', title)
     fd.append('main_artist_id', mainArtistId)
     if (cover) fd.append('cover', cover)
     fd.append('releaseDate', releaseDate)
-    fd.append('tracks', JSON.stringify(tracks.map(t => ({ title: t.title, lyrics: t.lyrics, featuredArtists: t.featuredArtists }))))
+    fd.append(
+      'tracks',
+      JSON.stringify(
+        tracks.map(t => ({
+          title: t.title,
+          lyrics: t.lyrics,
+          featuredArtists: t.featuredArtists,
+        }))
+      )
+    )
     tracks.forEach((t, idx) => {
       if (t.file) fd.append(`trackFile${idx}`, t.file)
     })
 
-    startTransition(async () => {
-      const res = await uploadAlbumAction(fd)
-      if (res.success) { setMessage('Album uploaded'); reset() } else setMessage('Upload failed')
-    })
+    const res = await uploadAlbum(fd)
+    if (res.success) {
+      toast('Album uploaded successfully')
+      reset()
+    } else {
+      toast(res.message || 'Upload failed')
+    }
   }
 
   return (
     <GlassCard className="p-8">
-      <form onSubmit={onSubmit} className="space-y-6">
-        {message && <p className="text-lg">{message}</p>}
+      <form onSubmit={onSubmit} className="space-y-6 text-lg">
         <div className="space-y-3">
           <label htmlFor="albumTitle" className="text-lg font-medium">Album Title</label>
           <Input
@@ -78,18 +89,17 @@ export default function UploadAlbumForm() {
           />
         </div>
         <div className="space-y-3">
-          <label htmlFor="albumArtist" className="text-lg font-medium">Artist</label>
-          <select
+          <label htmlFor="albumArtist" className="text-lg font-medium">Main Artist</label>
+          <input
             id="albumArtist"
+            list="album-artists"
             value={mainArtistId}
             onChange={e => setMainArtistId(e.target.value)}
             className="w-full rounded-md border border-white/20 bg-white/10 px-4 py-3 text-lg text-white"
-          >
-            <option value="">Select an artist</option>
-            {artists.map(a => (
-              <option key={a.id} value={a.id}>{a.name}</option>
-            ))}
-          </select>
+          />
+          <datalist id="album-artists">
+            {artists.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+          </datalist>
         </div>
         <div className="space-y-3">
           <label htmlFor="cover" className="text-lg font-medium">Cover</label>
@@ -167,8 +177,9 @@ export default function UploadAlbumForm() {
         </div>
         <button
           disabled={pending}
-          className="rounded-lg bg-white/10 px-6 py-3 text-lg text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:opacity-50"
+          className="flex items-center gap-3 rounded-lg bg-white/10 px-6 py-3 text-lg text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:opacity-50"
         >
+          {pending && <span className="h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />}
           Upload Album
         </button>
       </form>

--- a/components/upload/useAlbumUpload.ts
+++ b/components/upload/useAlbumUpload.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+import { uploadAlbumAction } from '../../app/actions/uploadAlbumAction'
+
+export function useAlbumUpload() {
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  const uploadAlbum = async (formData: FormData) => {
+    setPending(true)
+    setError(null)
+    setSuccess(false)
+    try {
+      const res = await uploadAlbumAction(formData)
+      if (!res.success) {
+        setError(res.message || 'Upload failed')
+      } else {
+        setSuccess(true)
+      }
+      return res
+    } catch (err: any) {
+      setError(err.message || 'Upload failed')
+      return { success: false, message: err.message }
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return { uploadAlbum, pending, error, success }
+}
+


### PR DESCRIPTION
## Summary
- refactor UploadAlbumForm with album fields and dynamic track groups
- add uploadAlbumAction to create albums, upload cover art and track audio
- add useAlbumUpload hook for stateful album uploads

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689280d252608324a06163379f9db551