### PR TITLE
feat: add playlist creator quick access

### DIFF
--- a/components/pages/DashboardPage.tsx
+++ b/components/pages/DashboardPage.tsx
@@ -42,7 +42,7 @@ const quickAccessCards = [
     glowColor: "shadow-purple-500/25"
   },
   {
-    title: "Manage Artists", 
+    title: "Manage Artists",
     description: "Browse and edit artist profiles",
     icon: Mic,
     iconColor: "text-emerald-400",
@@ -50,6 +50,16 @@ const quickAccessCards = [
     borderColor: "border-emerald-500/30",
     page: "Artists",
     glowColor: "shadow-emerald-500/25"
+  },
+  {
+    title: "Playlist Creator",
+    description: "Build and organize playlists",
+    icon: Music,
+    iconColor: "text-violet-400",
+    bgGradient: "from-violet-600/20 to-indigo-600/20",
+    borderColor: "border-violet-500/30",
+    page: "Playlists",
+    glowColor: "shadow-violet-500/25"
   },
   {
     title: "Platform Users",


### PR DESCRIPTION
## Summary
- expose playlist creator from dashboard quick access

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68929dd0e8ec8324889fa0460613fc65