### PR TITLE
Improve Supabase upload error logging

### DIFF
--- a/app/actions/upload.ts
+++ b/app/actions/upload.ts
@@ -3,6 +3,7 @@
 import slugify from 'slugify'
 import { supabaseAdmin } from '../../utils/supabase/serverClient'
 import { supabaseBrowser } from '../../utils/supabase/supabaseClient'
+import { logError } from '../../utils/logger'
 
 const getSupabase = () =>
   typeof window === 'undefined' ? supabaseAdmin() : supabaseBrowser()
@@ -14,12 +15,13 @@ export async function uploadSingleAction(
   formData: FormData
 ): Promise<{ success: boolean; message?: string }> {
   const supabase = getSupabase()
-  const { data: authData, error: authError } = await supabase.auth.getUser()
-  if (authError) {
-    console.error('Auth fetch error:', authError.message)
-    return { success: false, message: authError.message }
-  }
-  const userId = authData?.user?.id || null
+  try {
+    const { data: authData, error: authError } = await supabase.auth.getUser()
+    if (authError) {
+      logError('Auth fetch error', authError)
+      return { success: false, message: authError.message }
+    }
+    const userId = authData?.user?.id || null
 
   const title = formData.get('title') as string
   const artistId = formData.get('artist') as string
@@ -37,26 +39,26 @@ export async function uploadSingleAction(
   const slug = slugify(title, { lower: true, strict: true })
 
   // Upload audio file
-  const { data: audioData, error: audioError } = await supabase.storage
-    .from('audio-files')
-    .upload(`audio/${slug}-${Date.now()}`, audio)
-  if (audioError) {
-    console.error('Audio upload error:', audioError.message)
-    return { success: false, message: audioError.message }
-  }
-  const audioUrl = audioData.path
+    const { data: audioData, error: audioError } = await supabase.storage
+      .from('audio-files')
+      .upload(`audio/${slug}-${Date.now()}`, audio)
+    if (audioError || !audioData) {
+      logError('Audio upload error', audioError)
+      return { success: false, message: audioError?.message }
+    }
+    const audioUrl = audioData.path
 
   // Upload cover image if provided
   let coverPath: string | null = null
   if (cover) {
-    const { data: coverData, error: coverError } = await supabase.storage
-      .from('images')
-      .upload(`covers/${slug}-${Date.now()}`, cover)
-    if (coverError) {
-      console.error('Cover upload error:', coverError.message)
-      return { success: false, message: coverError.message }
-    }
-    coverPath = coverData.path
+      const { data: coverData, error: coverError } = await supabase.storage
+        .from('images')
+        .upload(`covers/${slug}-${Date.now()}`, cover)
+      if (coverError || !coverData) {
+        logError('Cover upload error', coverError)
+        return { success: false, message: coverError?.message }
+      }
+      coverPath = coverData.path
   }
 
   // Parse featured artist IDs
@@ -78,7 +80,7 @@ export async function uploadSingleAction(
   const genres = [genre, mood].filter(Boolean)
 
   // Insert track record
-  const { error } = await supabase.from('tracks').insert({
+    const { error } = await supabase.from('tracks').insert({
     title,
     artist_id: artistId,
     audio_url: audioUrl,
@@ -93,12 +95,16 @@ export async function uploadSingleAction(
     slug,
     created_by: userId,
   })
-  if (error) {
-    console.error('Track insert error:', error.message)
-    return { success: false, message: error.message }
-  }
+    if (error) {
+      logError('Track insert error', error)
+      return { success: false, message: error.message }
+    }
 
-  return { success: true }
+    return { success: true }
+  } catch (err: any) {
+    logError('Upload single unexpected error', err)
+    return { success: false, message: err.message }
+  }
 }
 
 /**
@@ -117,21 +123,26 @@ export async function uploadArtistAction(
   payload: UploadArtistPayload
 ): Promise<{ success: boolean; data?: any; error?: string }> {
   const supabase = getSupabase()
-  const { data: authData, error: authError } = await supabase.auth.getUser()
-  if (authError) {
-    console.error('Auth fetch error:', authError.message)
-    return { success: false, error: authError.message }
-  }
-  const userId = authData?.user?.id || null
+  try {
+    const { data: authData, error: authError } = await supabase.auth.getUser()
+    if (authError) {
+      logError('Auth fetch error', authError)
+      return { success: false, error: authError.message }
+    }
+    const userId = authData?.user?.id || null
 
-  const { data, error } = await supabase.from('artists').insert([
-    { ...payload, created_by: userId }
-  ])
-  if (error) {
-    console.error('Artist insert error:', error.message)
-    return { success: false, error: error.message }
+    const { data, error } = await supabase.from('artists').insert([
+      { ...payload, created_by: userId }
+    ])
+    if (error) {
+      logError('Artist insert error', error)
+      return { success: false, error: error.message }
+    }
+    return { success: true, data }
+  } catch (err: any) {
+    logError('Upload artist unexpected error', err)
+    return { success: false, error: err.message }
   }
-  return { success: true, data }
 }
 
 
@@ -156,65 +167,70 @@ export async function upsertPlaylistAction(
   payload: UpsertPlaylistPayload
 ): Promise<{ success: boolean; message?: string; id?: string }> {
   const supabase = getSupabase();
-  const { data: authData, error: authError } = await supabase.auth.getUser();
-  if (authError) {
-    console.error('Auth fetch error:', authError.message);
-    return { success: false, message: authError.message };
-  }
-  const userId = authData?.user?.id || null;
-
-  let coverUrl: string | null = null;
-  if (payload.cover) {
-    const ext = payload.cover.name.split('.').pop();
-    const path = `covers/${slugify(payload.name, { lower: true, strict: true })}-${Date.now()}.${ext}`;
-    const { data: coverData, error: coverError } = await supabase.storage
-      .from('images')
-      .upload(path, payload.cover);
-    if (coverError) {
-      console.error('Cover upload error:', coverError.message);
-      return { success: false, message: coverError.message };
+  try {
+    const { data: authData, error: authError } = await supabase.auth.getUser();
+    if (authError) {
+      logError('Auth fetch error', authError);
+      return { success: false, message: authError.message };
     }
-    coverUrl = coverData.path;
-  }
+    const userId = authData?.user?.id || null;
 
-  const { data: playlistData, error: playlistError } = await supabase
-    .from('playlists')
-    .upsert({
-      id: payload.id,
-      title: payload.name,
-      description: payload.description,
-      cover_url: coverUrl ?? undefined,
-      genres: payload.genres ?? null,
-      moods: payload.moods ?? null,
-      is_public: payload.isPublic ?? true,
-      sort_order: payload.sortOrder ?? null,
-      updated_by: userId,
-    })
-    .select()
-    .single();
-
-  if (playlistError) {
-    console.error('Playlist upsert error:', playlistError.message);
-    return { success: false, message: playlistError.message };
-  }
-
-  const playlistId = playlistData.id;
-
-  await supabase.from('playlist_tracks').delete().eq('playlist_id', playlistId);
-  const trackRows = payload.tracks.map((t) => ({
-    playlist_id: playlistId,
-    track_id: t.track_id,
-    position: t.position,
-  }));
-  if (trackRows.length) {
-    const { error: tracksError } = await supabase
-      .from('playlist_tracks')
-      .insert(trackRows);
-    if (tracksError) {
-      console.error('Playlist tracks insert error:', tracksError.message);
-      return { success: false, message: tracksError.message };
+    let coverUrl: string | null = null;
+    if (payload.cover) {
+      const ext = payload.cover.name.split('.').pop();
+      const path = `covers/${slugify(payload.name, { lower: true, strict: true })}-${Date.now()}.${ext}`;
+      const { data: coverData, error: coverError } = await supabase.storage
+        .from('images')
+        .upload(path, payload.cover);
+      if (coverError || !coverData) {
+        logError('Cover upload error', coverError);
+        return { success: false, message: coverError?.message };
+      }
+      coverUrl = coverData.path;
     }
-  }
 
-  return { success: true, id: playlistId };
+    const { data: playlistData, error: playlistError } = await supabase
+      .from('playlists')
+      .upsert({
+        id: payload.id,
+        title: payload.name,
+        description: payload.description,
+        cover_url: coverUrl ?? undefined,
+        genres: payload.genres ?? null,
+        moods: payload.moods ?? null,
+        is_public: payload.isPublic ?? true,
+        sort_order: payload.sortOrder ?? null,
+        updated_by: userId,
+      })
+      .select()
+      .single();
+
+    if (playlistError) {
+      logError('Playlist upsert error', playlistError);
+      return { success: false, message: playlistError.message };
+    }
+
+    const playlistId = playlistData.id;
+
+    await supabase.from('playlist_tracks').delete().eq('playlist_id', playlistId);
+    const trackRows = payload.tracks.map((t) => ({
+      playlist_id: playlistId,
+      track_id: t.track_id,
+      position: t.position,
+    }));
+    if (trackRows.length) {
+      const { error: tracksError } = await supabase
+        .from('playlist_tracks')
+        .insert(trackRows);
+      if (tracksError) {
+        logError('Playlist tracks insert error', tracksError);
+        return { success: false, message: tracksError.message };
+      }
+    }
+
+    return { success: true, id: playlistId };
+  } catch (err: any) {
+    logError('Upsert playlist unexpected error', err);
+    return { success: false, message: err.message };
+  }
 }

--- a/components/upload/UploadAlbumForm.tsx
+++ b/components/upload/UploadAlbumForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useAlbumUpload } from './useAlbumUpload'
 import { supabaseBrowser } from '../../utils/supabase/supabaseClient'
+import { logError } from '../../utils/logger'
 import { Input } from '../ui/input'
 import { Textarea } from '../ui/textarea'
 import { GlassCard } from '../common/GlassCard'
@@ -77,12 +78,18 @@ export default function UploadAlbumForm() {
       if (t.file) fd.append(`trackFile${idx}`, t.file)
     })
 
-    const res = await uploadAlbum(fd)
-    if (res.success) {
-      toast('Album uploaded successfully')
-      reset()
-    } else {
-      toast(res.message || 'Upload failed')
+    try {
+      const res = await uploadAlbum(fd)
+      if (res.success) {
+        toast('Album uploaded successfully')
+        reset()
+      } else {
+        logError('Album upload failed', res.message)
+        toast(res.message || 'Upload failed')
+      }
+    } catch (err: any) {
+      logError('Album upload error', err)
+      toast(err.message || 'Upload failed')
     }
   }
 

--- a/components/upload/UploadSingleForm.tsx
+++ b/components/upload/UploadSingleForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useTransition } from 'react'
 import { uploadSingleAction } from '../../app/actions/upload'
 import { supabaseBrowser } from '../../utils/supabase/supabaseClient'
+import { logError } from '../../utils/logger'
 import { Input } from '../ui/input'
 import { Textarea } from '../ui/textarea'
 import { GlassCard } from '../common/GlassCard'
@@ -73,9 +74,11 @@ export default function UploadSingleForm() {
           toast('Uploaded successfully')
           reset()
         } else {
+          logError('Single track upload failed', res.message)
           toast(res.message || 'Upload failed')
         }
       } catch (err: any) {
+        logError('Single track upload error', err)
         toast(err.message || 'Upload failed')
       }
     })

--- a/components/upload/useAlbumUpload.ts
+++ b/components/upload/useAlbumUpload.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { uploadAlbumAction } from '../../app/actions/uploadAlbumAction'
+import { logError } from '../../utils/logger'
 
 export function useAlbumUpload() {
   const [pending, setPending] = useState(false)
@@ -13,12 +14,14 @@ export function useAlbumUpload() {
     try {
       const res = await uploadAlbumAction(formData)
       if (!res.success) {
+        logError('Album upload action failed', res.message)
         setError(res.message || 'Upload failed')
       } else {
         setSuccess(true)
       }
       return res
     } catch (err: any) {
+      logError('Album upload hook error', err)
       setError(err.message || 'Upload failed')
       return { success: false, message: err.message }
     } finally {

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,9 @@
+export function logError(context: string, error: unknown) {
+  if (error instanceof Error) {
+    console.error(`${context}:`, error.message, error)
+  } else {
+    console.error(`${context}:`, error)
+  }
+}
+
+export default logError


### PR DESCRIPTION
## Summary
- add reusable `logError` helper for consistent logging
- wrap Supabase upload actions with try/catch and detailed `logError` calls
- surface upload errors in client forms and hooks

## Testing
- `npm run test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892a527553483248d23323218b379ac