### PR TITLE
feat: validate artist selections

### DIFF
--- a/app/actions/uploadAlbumAction.ts
+++ b/app/actions/uploadAlbumAction.ts
@@ -110,6 +110,7 @@ export async function uploadAlbumAction(formData: FormData): Promise<Result> {
         .from('tracks')
         .insert({
           title: meta.title,
+          artist_id: mainArtistId,
           lyrics: meta.lyrics ?? null,
           featured_artist_ids: featuredArtistIds,
           album_id: albumId,


### PR DESCRIPTION
## Summary
- validate and preview selected artists when uploading albums and tracks
- ensure album track rows store the main artist ID

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689382e1b2c08324b6455034a5e18fd8