### PR TITLE
feat: add artist feature flags and genres

### DIFF
--- a/app/actions/upload.ts
+++ b/app/actions/upload.ts
@@ -126,12 +126,15 @@ export async function uploadSingleAction(
  * Inserts a new artist record, using current user as creator.
  */
 export type UploadArtistPayload = {
+  id: string
   name: string
   bio?: string
   avatar_url?: string
   profile_picture_url?: string
   image_url?: string
-  status?: string
+  genres?: string[]
+  is_featured?: boolean
+  is_verified?: boolean
 }
 
 export async function uploadArtistAction(

--- a/components/artists/AddArtistForm.tsx
+++ b/components/artists/AddArtistForm.tsx
@@ -6,14 +6,16 @@ import { Textarea } from '../ui/textarea'
 import { GlassCard } from '../common/GlassCard'
 import { logError } from '../../utils/logger'
 
-export function AddArtistForm() {
+export function AddArtistForm({ onSuccess }: { onSuccess?: () => void }) {
   // Form state
   const [name, setName] = useState('')
   const [bio, setBio] = useState('')
   const [avatarUrl, setAvatarUrl] = useState('')
   const [profilePictureUrl, setProfilePictureUrl] = useState('')
   const [imageUrl, setImageUrl] = useState('')
-  const [status, setStatus] = useState('verified')
+  const [genres, setGenres] = useState('')
+  const [isFeatured, setIsFeatured] = useState(false)
+  const [isVerified, setIsVerified] = useState(true)
   const [message, setMessage] = useState('')
   const [pending, startTransition] = useTransition()
 
@@ -82,12 +84,18 @@ export function AddArtistForm() {
     startTransition(async () => {
       try {
         const payload = {
+          id: crypto.randomUUID(),
           name,
           bio,
           avatar_url: avatarUrl,
           profile_picture_url: profilePictureUrl,
           image_url: imageUrl,
-          status,
+          genres: genres
+            .split(',')
+            .map(g => g.trim())
+            .filter(Boolean),
+          is_featured: isFeatured,
+          is_verified: isVerified,
         }
 
         const res = await uploadArtistAction(payload)
@@ -98,7 +106,10 @@ export function AddArtistForm() {
           setAvatarUrl('')
           setProfilePictureUrl('')
           setImageUrl('')
-          setStatus('verified')
+          setGenres('')
+          setIsFeatured(false)
+          setIsVerified(true)
+          onSuccess?.()
         } else {
           logError('Artist save failed', res.error)
           setMessage('Failed to save artist')
@@ -137,6 +148,16 @@ export function AddArtistForm() {
         </div>
 
         <div className="space-y-3">
+          <label htmlFor="genres" className="text-lg font-medium">Genres (comma separated)</label>
+          <Input
+            id="genres"
+            value={genres}
+            onChange={e => setGenres(e.target.value)}
+            className="h-12 px-4 text-lg"
+          />
+        </div>
+
+        <div className="space-y-3">
           <label htmlFor="avatar" className="text-lg font-medium">Avatar Image</label>
           <input
             id="avatar"
@@ -169,18 +190,25 @@ export function AddArtistForm() {
           />
         </div>
 
-        <div className="space-y-3">
-          <label htmlFor="status" className="text-lg font-medium">Status</label>
-          <select
-            id="status"
-            value={status}
-            onChange={e => setStatus(e.target.value)}
-            className="w-full px-4 py-3 text-lg text-white border rounded-md border-white/20 bg-white/10"
-          >
-            <option value="verified">Verified</option>
-            <option value="pending">Pending</option>
-            <option value="suspended">Suspended</option>
-          </select>
+        <div className="flex items-center space-x-4">
+          <label className="flex items-center gap-2 text-lg font-medium">
+            <input
+              type="checkbox"
+              checked={isVerified}
+              onChange={e => setIsVerified(e.target.checked)}
+              className="h-5 w-5"
+            />
+            Verified
+          </label>
+          <label className="flex items-center gap-2 text-lg font-medium">
+            <input
+              type="checkbox"
+              checked={isFeatured}
+              onChange={e => setIsFeatured(e.target.checked)}
+              className="h-5 w-5"
+            />
+            Featured
+          </label>
         </div>
 
         <button

--- a/components/pages/ArtistsPage.tsx
+++ b/components/pages/ArtistsPage.tsx
@@ -37,11 +37,12 @@ export function ArtistsPage() {
 
   const filteredArtists = (artists || []).filter(artist =>
     artist.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    artist.genre?.toLowerCase().includes(searchTerm.toLowerCase())
+    (artist.genres || [])
+      .some((g: string) => g.toLowerCase().includes(searchTerm.toLowerCase()))
   );
 
-  const getStatusBadge = (status: string) => {
-    if (status === "verified") {
+  const getStatusBadge = (verified: boolean) => {
+    if (verified) {
       return (
         <div className="flex items-center gap-1 px-3 py-1 rounded-full bg-green-600 text-white text-xs font-medium">
           <Star className="w-3 h-3" />
@@ -132,13 +133,20 @@ export function ArtistsPage() {
                       </AvatarFallback>
                     </Avatar>
                     <div>
-                      <h3 className="font-bold text-lg">{artist.name}</h3>
-                      <p className="text-dark-secondary font-medium">{artist.genre}</p>
+                      <h3 className="font-bold text-lg">
+                        {artist.name}
+                        {artist.is_featured && (
+                          <Star className="inline w-4 h-4 ml-1 text-yellow-400" />
+                        )}
+                      </h3>
+                      <p className="text-dark-secondary font-medium">
+                        {(artist.genres && artist.genres[0]) || ''}
+                      </p>
                     </div>
                   </div>
 
                   <div className="flex items-center space-x-2">
-                    {getStatusBadge(artist.status)}
+                    {getStatusBadge(artist.is_verified)}
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <button className="p-2 hover:bg-dark-hover rounded-lg transition-colors">
@@ -171,7 +179,7 @@ export function ArtistsPage() {
                   <div className="text-center">
                     <div className="flex items-center justify-center mb-1">
                       <Users className="w-4 h-4 text-dark-secondary mr-1" />
-                      <span className="font-bold">{artist.followers}</span>
+                      <span className="font-bold">{artist.followers_count}</span>
                     </div>
                     <p className="text-xs text-dark-secondary">Followers</p>
                   </div>


### PR DESCRIPTION
## Summary
- allow admins to set genres, featured, and verified flags when creating artists
- generate stable UUID for new artists and persist via upload action
- display featured and verification status, genres, and follower counts on artists page

## Testing
- `npm run test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68938f0408b083249493defbe679e8d9